### PR TITLE
Add new banner component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.9.0)
+    govuk-design-system-rails (0.9.1)
 
 GEM
   remote: https://rubygems.org/

--- a/app/helpers/govuk_design_system/notification_banner_helper.rb
+++ b/app/helpers/govuk_design_system/notification_banner_helper.rb
@@ -1,0 +1,7 @@
+module GovukDesignSystem
+  module NotificationBannerHelper
+    def govukNotificationBanner(kwargs = {})
+      render "components/govuk_notification_banner", **kwargs
+    end
+  end
+end

--- a/app/helpers/govuk_design_system/notification_banner_helper.rb
+++ b/app/helpers/govuk_design_system/notification_banner_helper.rb
@@ -1,6 +1,7 @@
 module GovukDesignSystem
   module NotificationBannerHelper
-    def govukNotificationBanner(kwargs = {})
+    def govukNotificationBanner(kwargs = {}, &block)
+      kwargs[:block] = block
       render "components/govuk_notification_banner", **kwargs
     end
   end

--- a/app/views/components/_govuk_notification_banner.html.erb
+++ b/app/views/components/_govuk_notification_banner.html.erb
@@ -1,0 +1,67 @@
+<%
+  if local_assigns[:type] ==  "success"
+    success_banner = true
+    type_class = "govuk-notification-banner--" + local_assigns[:type]
+  end
+
+  role = if local_assigns[:role]
+    local_assigns[:role]
+  elsif success_banner
+    "alert"
+  else
+    "region"
+  end
+
+  title = if local_assigns[:titleHtml]
+            local_assigns[:titleHtml]
+          elsif local_assigns[:titleText]
+            local_assigns[:titleText]
+          elsif success_banner
+            "Success"
+          else
+            "Important"
+          end
+
+  banner_classes =  class_names(
+    "govuk-notification-banner",
+    type_class,
+    local_assigns[:classes]
+  )
+
+  labelled_by = local_assigns[:titleId] || "govuk-notification-banner-title"
+
+  attributes = {
+    role: role,
+    "aria-labelledby" => labelled_by,
+    "data-module" => "govuk-notification-banner",
+    class: banner_classes
+  }.merge(local_assigns[:attributes] || {})
+
+  attributes.merge!({ "data-disable-auto-focus" => true }) if local_assigns[:disableAutoFocus]
+
+  title_heading_level = local_assigns[:title_heading_level] ? "h#{local_assigns[:title_heading_level]}" : "h2"
+
+  header_attributes = {
+    class: "govuk-notification-banner__title",
+    id: labelled_by
+  }
+%>
+
+<%= tag.div **attributes do %>
+  <div class="govuk-notification-banner__header">
+    <%= tag.send(title_heading_level, **header_attributes) do %>
+      <%= title %>
+    <% end %>
+  </div>
+  <div class="govuk-notification-banner__content">
+    <% if local_assigns[:block] %>
+      <%= yield %>
+    <% elsif local_assigns[:html] %>
+      <%= local_assigns[:html] %>
+    <% elsif local_assigns[:text] %>
+      <p class="govuk-notification-banner__heading">
+        <%= local_assigns[:text] %>
+      </p>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/components/_govuk_notification_banner.html.erb
+++ b/app/views/components/_govuk_notification_banner.html.erb
@@ -1,7 +1,8 @@
 <%
-  if local_assigns[:type] ==  "success"
+  banner_type = local_assigns[:type]&.to_s
+  if banner_type ==  "success"
     success_banner = true
-    type_class = "govuk-notification-banner--" + local_assigns[:type]
+    type_class = "govuk-notification-banner--" + banner_type
   end
 
   role = if local_assigns[:role]

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.9.0"
+  s.version     = "0.9.1"
   s.authors     = %w[UKGovernmentBEIS]
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.test_files  = Dir["spec/**/*"]

--- a/lib/govuk_design_system/engine.rb
+++ b/lib/govuk_design_system/engine.rb
@@ -26,6 +26,7 @@ module GovukDesignSystem
         ActionView::Base.include GovukDesignSystem::HmctsBannerHelper
         ActionView::Base.include GovukDesignSystem::InputHelper
         ActionView::Base.include GovukDesignSystem::LabelHelper
+        ActionView::Base.include GovukDesignSystem::NotificationBannerHelper
         ActionView::Base.include GovukDesignSystem::PhaseBannerHelper
         ActionView::Base.include GovukDesignSystem::RadiosHelper
         ActionView::Base.include GovukDesignSystem::SelectHelper

--- a/spec/helpers/govuk_design_system/notification_banner_helper_spec.rb
+++ b/spec/helpers/govuk_design_system/notification_banner_helper_spec.rb
@@ -1,0 +1,79 @@
+require "rails_helper"
+
+RSpec.describe GovukDesignSystem::NotificationBannerHelper, type: :helper do
+  describe "#govukNotificationBanner" do
+    context "passing html to the component" do
+      it "returns the correct HTML" do
+        html = '<p class="govuk-notification-banner__heading">You have 7 days left to send your application.<a class="govuk-notification-banner__link" href="#">View application</a>.</p>'.html_safe
+        output = helper.govukNotificationBanner({
+          html: html,
+        })
+
+        expect(output).to match_html(<<~HTML)
+          <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+              Important
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">
+              You have 7 days left to send your application.
+              <a class="govuk-notification-banner__link" href="#">View application</a>.
+            </p>
+          </div>
+        </div>
+        HTML
+      end
+    end
+
+    context "text to the component" do
+        it "returns the correct HTML" do
+        output = helper.govukNotificationBanner({
+          text: 'There may be a delay in processing your application because of the coronavirus outbreak.'
+        })
+
+        expect(output).to match_html(<<~HTML)
+        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+          <div class="govuk-notification-banner__header">
+            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+              Important
+            </h2>
+          </div>
+          <div class="govuk-notification-banner__content">
+            <p class="govuk-notification-banner__heading">There may be a delay in processing your application because of the coronavirus outbreak.</p>
+          </div>
+        </div>
+        HTML
+      end
+    end
+
+    context "success banner" do
+      context "passing html to the component" do
+        it "returns the correct HTML for success" do
+          html = "<h3 class='govuk-notification-banner__heading'>Training outcome recorded and trainee withdrawn</h3><p class='govuk-body'>Contact <a class='govuk-notification-banner__link' href='#'>example@department.gov.uk</a> if you think there's a problem.</p>".html_safe
+          output = helper.govukNotificationBanner({
+            html: html,
+            type: "success"
+          })
+
+          expect(output).to match_html(<<~HTML)
+          <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Success
+              </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+              <h3 class="govuk-notification-banner__heading">
+                Training outcome recorded and trainee withdrawn
+              </h3>
+              <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="#">example@department.gov.uk</a> if you think there's a problem.</p>
+            </div>
+          </div>
+          HTML
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/govuk_design_system/notification_banner_helper_spec.rb
+++ b/spec/helpers/govuk_design_system/notification_banner_helper_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe GovukDesignSystem::NotificationBannerHelper, type: :helper do
   describe "#govukNotificationBanner" do
-    context "passing html to the component" do
+    context "when passing html to the component" do
       it "returns the correct HTML" do
         html = '<p class="govuk-notification-banner__heading">You have 7 days left to send your application.<a class="govuk-notification-banner__link" href="#">View application</a>.</p>'.html_safe
         output = helper.govukNotificationBanner({
@@ -10,46 +10,46 @@ RSpec.describe GovukDesignSystem::NotificationBannerHelper, type: :helper do
         })
 
         expect(output).to match_html(<<~HTML)
-          <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-          <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-              Important
-            </h2>
+            <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Important
+              </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+              <p class="govuk-notification-banner__heading">
+                You have 7 days left to send your application.
+                <a class="govuk-notification-banner__link" href="#">View application</a>.
+              </p>
+            </div>
           </div>
-          <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">
-              You have 7 days left to send your application.
-              <a class="govuk-notification-banner__link" href="#">View application</a>.
-            </p>
-          </div>
-        </div>
         HTML
       end
     end
 
-    context "text to the component" do
-        it "returns the correct HTML" do
+    context "when passing text to the component" do
+      it "returns the correct HTML" do
         output = helper.govukNotificationBanner({
-          text: 'There may be a delay in processing your application because of the coronavirus outbreak.'
+          text: "There may be a delay in processing your application because of the coronavirus outbreak."
         })
 
         expect(output).to match_html(<<~HTML)
-        <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-          <div class="govuk-notification-banner__header">
-            <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-              Important
-            </h2>
+          <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+            <div class="govuk-notification-banner__header">
+              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                Important
+              </h2>
+            </div>
+            <div class="govuk-notification-banner__content">
+              <p class="govuk-notification-banner__heading">There may be a delay in processing your application because of the coronavirus outbreak.</p>
+            </div>
           </div>
-          <div class="govuk-notification-banner__content">
-            <p class="govuk-notification-banner__heading">There may be a delay in processing your application because of the coronavirus outbreak.</p>
-          </div>
-        </div>
         HTML
       end
     end
 
-    context "success banner" do
-      context "passing html to the component" do
+    context "when rendering a success banner" do
+      context "when passing html to the component" do
         it "returns the correct HTML for success" do
           html = "<h3 class='govuk-notification-banner__heading'>Training outcome recorded and trainee withdrawn</h3><p class='govuk-body'>Contact <a class='govuk-notification-banner__link' href='#'>example@department.gov.uk</a> if you think there's a problem.</p>".html_safe
           output = helper.govukNotificationBanner({
@@ -58,19 +58,19 @@ RSpec.describe GovukDesignSystem::NotificationBannerHelper, type: :helper do
           })
 
           expect(output).to match_html(<<~HTML)
-          <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-            <div class="govuk-notification-banner__header">
-              <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-                Success
-              </h2>
+            <div class="govuk-notification-banner govuk-notification-banner--success" role="alert" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
+              <div class="govuk-notification-banner__header">
+                <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
+                  Success
+                </h2>
+              </div>
+              <div class="govuk-notification-banner__content">
+                <h3 class="govuk-notification-banner__heading">
+                  Training outcome recorded and trainee withdrawn
+                </h3>
+                <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="#">example@department.gov.uk</a> if you think there's a problem.</p>
+              </div>
             </div>
-            <div class="govuk-notification-banner__content">
-              <h3 class="govuk-notification-banner__heading">
-                Training outcome recorded and trainee withdrawn
-              </h3>
-              <p class="govuk-body">Contact <a class="govuk-notification-banner__link" href="#">example@department.gov.uk</a> if you think there's a problem.</p>
-            </div>
-          </div>
           HTML
         end
       end


### PR DESCRIPTION
This PR adds the [notification banner component](https://design-system.service.gov.uk/components/notification-banner/) that can be found in govuk frontend [here](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/notification-banner/template.njk)