### PR TITLE
Fix missing class on form group when govukInput has an error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.9.4)
+    govuk-design-system-rails (0.9.5)
 
 GEM
   remote: https://rubygems.org/
@@ -131,7 +131,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (2.5.0)
+    regexp_parser (2.6.0)
     rexml (3.2.5)
     rspec-core (3.11.0)
       rspec-support (~> 3.11.0)
@@ -141,14 +141,14 @@ GEM
     rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-rails (5.1.2)
-      actionpack (>= 5.2)
-      activesupport (>= 5.2)
-      railties (>= 5.2)
-      rspec-core (~> 3.10)
-      rspec-expectations (~> 3.10)
-      rspec-mocks (~> 3.10)
-      rspec-support (~> 3.10)
+    rspec-rails (6.0.0)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+      railties (>= 6.1)
+      rspec-core (~> 3.11)
+      rspec-expectations (~> 3.11)
+      rspec-mocks (~> 3.11)
+      rspec-support (~> 3.11)
     rspec-support (3.11.1)
     rubocop (1.35.0)
       json (~> 2.3)
@@ -187,7 +187,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.5.0)
+    sqlite3 (1.5.3)
       mini_portile2 (~> 2.8.0)
     super_diff (0.9.0)
       attr_extras (>= 6.2.4)
@@ -200,7 +200,7 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
   ruby

--- a/app/views/components/_govuk_input.html.erb
+++ b/app/views/components/_govuk_input.html.erb
@@ -1,7 +1,7 @@
 <% described_by = local_assigns[:describedBy] %>
 <% form_group_classes = class_names(
     'govuk-form-group',
-    { 'govuk-form-group--error' => local_assigns.dig(:formGroup, :errorMessage) },
+    { 'govuk-form-group--error' => local_assigns[:errorMessage] },
     local_assigns.dig(:formGroup, :classes)
   )
 %>

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.9.4"
+  s.version     = "0.9.5"
   s.authors     = %w[OfficeForProductSafetyAndStandards]
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.test_files  = Dir["spec/**/*"]

--- a/spec/helpers/govuk_design_system/input_helper_spec.rb
+++ b/spec/helpers/govuk_design_system/input_helper_spec.rb
@@ -113,5 +113,45 @@ RSpec.describe GovukDesignSystem::InputHelper, type: :helper do
         </div>
       HTML
     end
+
+    it "handles error messages correctly" do
+      html = helper.govukInput({
+        id: "cost-per-item-error",
+        name: "cost-per-item-error",
+        label: {
+          text: "What is the cost per item, in pounds?",
+          classes: "govuk-label--l",
+          isPageHeading: true
+        },
+        prefix: {
+          text: "£"
+        },
+        suffix: {
+          text: "per item"
+        },
+        errorMessage: {
+          text: "Enter a cost per item, in pounds"
+        },
+        classes: "govuk-input--width-5",
+        spellcheck: false
+      })
+
+      expect(html).to match_html(<<~HTML)
+        <div class="govuk-form-group govuk-form-group--error">
+          <h1 class="govuk-label-wrapper"><label class="govuk-label govuk-label--l" for="cost-per-item-error">
+              What is the cost per item, in pounds?
+            </label>
+          </h1>
+          <p id="cost-per-item-error-error" class="govuk-error-message">
+            <span class="govuk-visually-hidden">Error:</span> Enter a cost per item, in pounds
+          </p>
+          <div class="govuk-input__wrapper">
+            <div class="govuk-input__prefix" aria-hidden="true">£</div>
+            <input class="govuk-input govuk-input--width-5 govuk-input--error" id="cost-per-item-error" name="cost-per-item-error" type="text" spellcheck="false" aria-describedby="cost-per-item-error-error">
+            <div class="govuk-input__suffix" aria-hidden="true">per item</div>
+          </div>
+        </div>
+      HTML
+    end
   end
 end


### PR DESCRIPTION
Fixes a styling bug: When a `govukInput` had an `errorMessage`, the `govuk-form-group--error` class was not being applied to the wrapping `div` tag. This meant the red bar was not visible to the left of these inputs.

Incorrect (current) behaviour:

![image](https://user-images.githubusercontent.com/85587097/195347251-d8a9b417-3431-48c0-a472-a6e078171fce.png)

Correct (new) behaviour:

![image](https://user-images.githubusercontent.com/85587097/195347349-69d487a5-22c2-4201-92b1-21135adf66a4.png)