### PR TITLE
Add inset text component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk-design-system-rails (0.9.5)
+    govuk-design-system-rails (0.9.6)
 
 GEM
   remote: https://rubygems.org/

--- a/app/helpers/govuk_design_system/inset_text_helper.rb
+++ b/app/helpers/govuk_design_system/inset_text_helper.rb
@@ -1,0 +1,9 @@
+module GovukDesignSystem
+  # Based on https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/inset-text/template.njk
+  module InsetTextHelper
+    def govukInsetText(kwargs = {}, &block)
+      kwargs[:block] = block
+      render "components/govuk_inset_text", **kwargs
+    end
+  end
+end

--- a/app/views/components/_govuk_inset_text.html.erb
+++ b/app/views/components/_govuk_inset_text.html.erb
@@ -1,0 +1,10 @@
+<%
+  div_attributes = {
+    class: class_names("govuk-inset-text", local_assigns[:classes]),
+  }.merge!(local_assigns[:attributes].presence || {})
+  div_attributes[:id] = local_assigns[:id] if local_assigns[:id].present?
+%>
+<%= tag.div **div_attributes do %>
+  <%= local_assigns[:html] || local_assigns[:text] %>
+  <%= capture(&block) if block %>
+<% end %>

--- a/govuk_design_system-rails.gemspec
+++ b/govuk_design_system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "govuk-design-system-rails"
-  s.version     = "0.9.5"
+  s.version     = "0.9.6"
   s.authors     = %w[OfficeForProductSafetyAndStandards]
   s.summary     = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.test_files  = Dir["spec/**/*"]

--- a/lib/govuk_design_system/engine.rb
+++ b/lib/govuk_design_system/engine.rb
@@ -25,6 +25,7 @@ module GovukDesignSystem
         ActionView::Base.include GovukDesignSystem::HmctsBadgeHelper
         ActionView::Base.include GovukDesignSystem::HmctsBannerHelper
         ActionView::Base.include GovukDesignSystem::InputHelper
+        ActionView::Base.include GovukDesignSystem::InsetTextHelper
         ActionView::Base.include GovukDesignSystem::LabelHelper
         ActionView::Base.include GovukDesignSystem::NotificationBannerHelper
         ActionView::Base.include GovukDesignSystem::PhaseBannerHelper

--- a/spec/helpers/govuk_design_system/inset_text_helper_spec.rb
+++ b/spec/helpers/govuk_design_system/inset_text_helper_spec.rb
@@ -16,18 +16,18 @@ RSpec.describe GovukDesignSystem::InsetTextHelper, type: :helper do
 
     it "returns the correct HTML for an example using html" do
       inset_html = '<p class="govuk-body-l govuk-!-margin-bottom-4">
-                            Creating a case starts from a product record page.
-                        </p>
-                        <p class="govuk-body">
-                            Find a product and create the case from there.
-                        </p>
-                        <details class="govuk-details" data-module="govuk-details">
-                            <summary class="govuk-details__summary">
-                              <span class="govuk-details__summary-text">
-                                How to create a case
-                              </span>
-                            </summary>
-                        </details>'.html_safe
+                      Creating a case starts from a product record page.
+                    </p>
+                    <p class="govuk-body">
+                      Find a product and create the case from there.
+                    </p>
+                    <details class="govuk-details" data-module="govuk-details">
+                      <summary class="govuk-details__summary">
+                        <span class="govuk-details__summary-text">
+                          How to create a case
+                        </span>
+                      </summary>
+                    </details>'.html_safe
 
       html = helper.govukInsetText({
         classes: "govuk-!-margin-bottom-7",
@@ -35,20 +35,20 @@ RSpec.describe GovukDesignSystem::InsetTextHelper, type: :helper do
       })
 
       expect(html).to match_html(<<~HTML)
-       <div class="govuk-inset-text govuk-!-margin-bottom-7">
-            <p class="govuk-body-l govuk-!-margin-bottom-4">
-                Creating a case starts from a product record page.
-            </p>
-            <p class="govuk-body">
-                Find a product and create the case from there.
-            </p>
-            <details class="govuk-details" data-module="govuk-details">
-                <summary class="govuk-details__summary">
-                  <span class="govuk-details__summary-text">
-                    How to create a case
-                  </span>
-                </summary>
-            </details>
+        <div class="govuk-inset-text govuk-!-margin-bottom-7">
+          <p class="govuk-body-l govuk-!-margin-bottom-4">
+            Creating a case starts from a product record page.
+          </p>
+          <p class="govuk-body">
+            Find a product and create the case from there.
+          </p>
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                How to create a case
+              </span>
+            </summary>
+          </details>
         </div>
       HTML
     end

--- a/spec/helpers/govuk_design_system/inset_text_helper_spec.rb
+++ b/spec/helpers/govuk_design_system/inset_text_helper_spec.rb
@@ -15,19 +15,21 @@ RSpec.describe GovukDesignSystem::InsetTextHelper, type: :helper do
     end
 
     it "returns the correct HTML for an example using html" do
-      inset_html = '<p class="govuk-body-l govuk-!-margin-bottom-4">
-                      Creating a case starts from a product record page.
-                    </p>
-                    <p class="govuk-body">
-                      Find a product and create the case from there.
-                    </p>
-                    <details class="govuk-details" data-module="govuk-details">
-                      <summary class="govuk-details__summary">
-                        <span class="govuk-details__summary-text">
-                          How to create a case
-                        </span>
-                      </summary>
-                    </details>'.html_safe
+      inset_html = <<~HTML.html_safe
+        <p class="govuk-body-l govuk-!-margin-bottom-4">
+          Creating a case starts from a product record page.
+        </p>
+        <p class="govuk-body">
+          Find a product and create the case from there.
+        </p>
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              How to create a case
+            </span>
+          </summary>
+        </details>
+      HTML
 
       html = helper.govukInsetText({
         classes: "govuk-!-margin-bottom-7",

--- a/spec/helpers/govuk_design_system/inset_text_helper_spec.rb
+++ b/spec/helpers/govuk_design_system/inset_text_helper_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe GovukDesignSystem::InsetTextHelper, type: :helper do
+  describe "#govukInsetText" do
+    it "returns the correct HTML for the default example" do
+      html = helper.govukInsetText({
+        text: "It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application."
+      })
+
+      expect(html).to match_html(<<~HTML)
+        <div class="govuk-inset-text">
+          It can take up to 8 weeks to register a lasting power of attorney if there are no mistakes in the application.
+        </div>
+      HTML
+    end
+
+    it "returns the correct HTML for an example using html" do
+      inset_html = '<p class="govuk-body-l govuk-!-margin-bottom-4">
+                            Creating a case starts from a product record page.
+                        </p>
+                        <p class="govuk-body">
+                            Find a product and create the case from there.
+                        </p>
+                        <details class="govuk-details" data-module="govuk-details">
+                            <summary class="govuk-details__summary">
+                              <span class="govuk-details__summary-text">
+                                How to create a case
+                              </span>
+                            </summary>
+                        </details>'.html_safe
+
+      html = helper.govukInsetText({
+        classes: "govuk-!-margin-bottom-7",
+        html: inset_html
+      })
+
+      expect(html).to match_html(<<~HTML)
+       <div class="govuk-inset-text govuk-!-margin-bottom-7">
+            <p class="govuk-body-l govuk-!-margin-bottom-4">
+                Creating a case starts from a product record page.
+            </p>
+            <p class="govuk-body">
+                Find a product and create the case from there.
+            </p>
+            <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    How to create a case
+                  </span>
+                </summary>
+            </details>
+        </div>
+      HTML
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the [inset text component](https://design-system.service.gov.uk/components/inset-text/) that can be found in govuk frontend [here](https://github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/inset-text/template.njk)