### PR TITLE
Manually require all dependencies

### DIFF
--- a/govuk-design-system-rails.gemspec
+++ b/govuk-design-system-rails.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name = "govuk-design-system-rails"
-  s.version = "0.10.4"
+  s.version = "0.10.5"
   s.authors = %w[govuk-ruby]
   s.summary = "An implementation of the govuk-frontend macros in Ruby on Rails"
   s.homepage = "https://github.com/govuk-ruby/govuk-design-system-rails"

--- a/lib/govuk_design_system/engine.rb
+++ b/lib/govuk_design_system/engine.rb
@@ -7,6 +7,8 @@ module GovukDesignSystem
         # NOTE: These includes make the helpers available in every view of the
         #   consuming application. If a helper is not listed here, it will be
         #   isolated, and unavailable to apps which use this gem.
+        Dir[GovukDesignSystem::Engine.root.join("app", "helpers", "govuk_design_system", "*.rb")].sort.each { |f| require f }
+
         ActionView::Base.include GovukDesignSystem::AccordionHelper
         ActionView::Base.include GovukDesignSystem::BackLinkHelper
         ActionView::Base.include GovukDesignSystem::BreadcrumbsHelper


### PR DESCRIPTION
Requires all dependencies from the engine to make this gem compatible with the `govuk_design_system_formbuilder` gem.